### PR TITLE
✨ Add support for Canvas docs block

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,4 +1,4 @@
 module.exports = {
   stories: ["../stories/**/*.stories.mdx", "../stories/**/*.stories.@(js|jsx|ts|tsx)"],
-  addons: ["../preset.js"],
+  addons: ["@storybook/addon-docs", "../preset.js"],
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@babel/core": "^7.12.3",
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.5",
+    "@storybook/addon-docs": "^6.3.4",
     "@storybook/react": "^6.1.14",
     "auto": "^10.16.8",
     "babel-loader": "^8.1.0",

--- a/src/withPseudoState.js
+++ b/src/withPseudoState.js
@@ -1,6 +1,6 @@
 /* eslint-env browser */
 import { addons, useEffect, useGlobals, useParameter } from "@storybook/addons"
-import { STORY_CHANGED, STORY_RENDERED } from "@storybook/core-events"
+import { DOCS_RENDERED, STORY_CHANGED, STORY_RENDERED } from "@storybook/core-events"
 
 import { PSEUDO_STATES } from "./constants"
 
@@ -37,26 +37,37 @@ const shadowHosts = new Set()
 addons.getChannel().on(STORY_CHANGED, () => shadowHosts.clear())
 
 // Global decorator that rewrites stylesheets and applies classnames to render pseudo styles
-export const withPseudoState = (StoryFn) => {
-  const parameter = useParameter("pseudo")
+export const withPseudoState = (StoryFn, { viewMode, parameters, id }) => {
+  const isDocs = viewMode === 'docs';
+  const { pseudo: parameter } = parameters;
   const [{ pseudo: globals }, updateGlobals] = useGlobals()
 
-  // Sync parameter to globals, used by the toolbar
+  // Sync parameter to globals, used by the toolbar (only in canvas as this
+  // doesn't make sense for docs because many stories are displayed at once)
   useEffect(() => {
-    if (parameter !== globals) updateGlobals({ pseudo: parameter })
-  }, [parameter])
+    if (parameter !== globals && !isDocs) updateGlobals({ pseudo: parameter })
+  }, [parameter, isDocs])
 
   // Convert selected states to classnames and apply them to the story root element.
   // Then update each shadow host to redetermine its own pseudo classnames.
   useEffect(() => {
-    applyClasses(
-      document.getElementById("root"),
-      Object.entries(globals || {})
-        .filter(([_, value]) => value)
-        .map(([key]) => `pseudo-${PSEUDO_STATES[key]}`)
-    )
-    shadowHosts.forEach(updateShadowHost)
-  }, [globals])
+    const apply = element => {
+      applyClasses(
+        element,
+        Object.entries(parameter || {})
+          .filter(([_, value]) => value)
+          .map(([key]) => `pseudo-${PSEUDO_STATES[key]}`)
+      )
+      shadowHosts.forEach(updateShadowHost)
+    }
+
+    if (isDocs) {
+      // Wait for the docs page to render so we can select the story element 😑
+      setTimeout(() => apply(document.getElementById(`story--${id}`)), 0);
+    } else {
+      apply(document.getElementById("root"));
+    }
+  }, [parameter])
 
   return StoryFn()
 }
@@ -117,6 +128,9 @@ function rewriteStyleSheets(shadowRoot) {
 
 // Reinitialize CSS enhancements every time the story changes
 addons.getChannel().on(STORY_RENDERED, () => rewriteStyleSheets())
+
+// Reinitialize CSS enhancements every time a docs page is rendered
+addons.getChannel().on(DOCS_RENDERED, () => rewriteStyleSheets())
 
 // IE doesn't support shadow DOM
 if (Element.prototype.attachShadow) {


### PR DESCRIPTION
Add support for the `psuedo` Story parameter for stories rendered in the `Canvas` block in MDX-based stories (the Docs addon).

Fixes #11 

- Rewrite stylesheets on the `DOCS_RENDERED` event in addition to `STORY_RENDERED`
- Apply the `.pseudo-[state]` classes directly to the story elements in docs pages

_👋🏻 I'm fairly new to some of the Storybook internals so I'd love to know if there's a better way to apply the CSS classes to individual stories in docs pages._

<img src="https://user-images.githubusercontent.com/288160/125976530-58f90715-ea35-48d5-aef6-d76ca8d1a724.gif">