### PR TITLE
add support for esm (#19)

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,3 +1,14 @@
+const modules = process.env.BABEL_ESM === 'true' ? false : 'auto';
+
 module.exports = {
-  presets: ["@babel/preset-env", "@babel/preset-react"],
+    presets: [
+        [
+            "@babel/preset-env",
+            {
+                targets: 'defaults',
+                modules
+            }
+        ],
+        "@babel/preset-react"
+    ],
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "author": "ghengeveld",
   "license": "MIT",
-  "main": "dist/preset.js",
+  "main": "dist/cjs/preset.js",
+  "module": "dist/esm/preset.js",
   "files": [
     "dist/**/*",
     "README.md",
@@ -25,7 +26,7 @@
     "start": "concurrently \"yarn storybook --no-manager-cache --quiet\" \"yarn build:dist --watch\"",
     "storybook": "start-storybook -p 6006",
     "chromatic": "chromatic",
-    "build:dist": "babel ./src --out-dir ./dist",
+    "build:dist": "babel ./src --out-dir ./dist/cjs && BABEL_ESM=\"true\" babel ./src --out-dir ./dist/esm",
     "build:storybook": "build-storybook",
     "prepublish": "yarn clean && yarn build:dist",
     "release": "auto shipit --base-branch=main"

--- a/preset.js
+++ b/preset.js
@@ -1,1 +1,9 @@
-module.exports = require("./dist/preset")
+function managerEntries(entry = []) {
+    return [...entry, require.resolve("./dist/esm/preset/manager")]
+}
+
+function config(entry = []) {
+    return [...entry, require.resolve("./dist/esm/preset/preview")]
+}
+
+module.exports = { managerEntries, config };

--- a/src/preset/index.js
+++ b/src/preset/index.js
@@ -1,7 +1,0 @@
-export function config(entry = []) {
-  return [...entry, require.resolve("./preview")]
-}
-
-export function managerEntries(entry = []) {
-  return [...entry, require.resolve("./manager")]
-}


### PR DESCRIPTION
To let this addon work properly with a VueJS + Vite + Storybook setup the addon must have a ESM build.
This PR adds an ESM build besides the CJS build based on https://github.com/storybookjs/storybook/commit/04acc44510fc189003e643c3262e1db46275f859