### PR TITLE
fix: only generate pseudo selector when the selector has a match

### DIFF
--- a/src/withPseudoState.js
+++ b/src/withPseudoState.js
@@ -99,7 +99,7 @@ function rewriteStyleSheets(shadowRoot) {
             selectorText,
             selectors
               .flatMap((selector) => {
-                if (selector.includes(`.pseudo-`)) return []
+                if (!matchOne.test(selector) || selector.includes(".pseudo-")) return []
                 const states = []
                 const plainSelector = selector.replace(matchAll, (_, state) => {
                   states.push(state)

--- a/src/withPseudoState.js
+++ b/src/withPseudoState.js
@@ -108,7 +108,8 @@ function rewriteStyleSheets(shadowRoot) {
                 let stateSelector
                 if (!matchOne.test(selector)) {
                   return [selector]
-                } else if (selector.startsWith(":host(") || selector.startsWith("::slotted(")) {
+                }
+                if (selector.startsWith(":host(") || selector.startsWith("::slotted(")) {
                   stateSelector = states.reduce(
                     (acc, state) => acc.replaceAll(`:${state}`, `.pseudo-${state}`),
                     selector

--- a/src/withPseudoState.js
+++ b/src/withPseudoState.js
@@ -99,14 +99,16 @@ function rewriteStyleSheets(shadowRoot) {
             selectorText,
             selectors
               .flatMap((selector) => {
-                if (!matchOne.test(selector) || selector.includes(".pseudo-")) return []
+                if (selector.includes(".pseudo-")) return []
                 const states = []
                 const plainSelector = selector.replace(matchAll, (_, state) => {
                   states.push(state)
                   return ""
                 })
                 let stateSelector
-                if (selector.startsWith(":host(") || selector.startsWith("::slotted(")) {
+                if (!matchOne.test(selector)) {
+                  return [selector]
+                } else if (selector.startsWith(":host(") || selector.startsWith("::slotted(")) {
                   stateSelector = states.reduce(
                     (acc, state) => acc.replaceAll(`:${state}`, `.pseudo-${state}`),
                     selector


### PR DESCRIPTION
With this change, a pseudo state selector is no longer generated for each selector inside a group. Previously, if there was a single match from a group, all selectors from the group would result in a generated pseudo state class. This would cause errors since incorrect CSS was generated. 

fixes #29 