### PR TITLE
feat: support pseudo selectors escape

### DIFF
--- a/src/rewriteStyleSheet.js
+++ b/src/rewriteStyleSheet.js
@@ -2,8 +2,17 @@ import { PSEUDO_STATES } from "./constants"
 import { splitSelectors } from "./splitSelectors"
 
 const pseudoStates = Object.values(PSEUDO_STATES)
-const matchOne = new RegExp(`:(${pseudoStates.join("|")})`)
-const matchAll = new RegExp(`:(${pseudoStates.join("|")})`, "g")
+/** skip odd number of '\' escapes
+ * but keep even
+ * @example
+ * skip \:pseudo-selector 
+ * skip \\\:pseudo-selector 
+ * 
+ * keep \\:pseudo-selector
+ * keep \\\\:pseudo-selector
+ */
+const matchOne = new RegExp(`(?<=(?<!\\\\)(?:\\\\\\\\)*):(${pseudoStates.join("|")})`)
+const matchAll = new RegExp(`(?<=(?<!\\\\)(?:\\\\\\\\)*):(${pseudoStates.join("|")})`, "g")
 
 const warnings = new Set()
 const warnOnce = (message) => {
@@ -31,7 +40,7 @@ const rewriteRule = (cssText, selectorText, shadowRoot) => {
           return ""
         })
         const classSelector = states.reduce(
-          (acc, state) => acc.replace(new RegExp(`:${state}`, "g"), `.pseudo-${state}`),
+          (acc, state) => acc.replace(new RegExp(`(?<=(?<!\\\\)(?:\\\\\\\\)*):${state}`, "g"), `.pseudo-${state}`),
           selector
         )
 

--- a/src/rewriteStyleSheet.test.js
+++ b/src/rewriteStyleSheet.test.js
@@ -63,4 +63,19 @@ describe("rewriteStyleSheet", () => {
     rewriteStyleSheet(sheet)
     expect(sheet.cssRules[0]).toEqual(":not(:hover), :not(.pseudo-hover) { color: red }")
   })
+
+
+  it('skips escaped pseduo-selectors "\\:hover"', () => {
+    const sheet = new Sheet("a\\:hover { color: red }")
+    rewriteStyleSheet(sheet)
+    expect(sheet.cssRules.length).toEqual(1)
+    expect(sheet.cssRules[0].cssText).toEqual("a\\:hover { color: red }")
+    expect(sheet.cssRules[0].selectorText).toEqual("a\\:hover")
+  })
+
+  it('supports "\\\\:hover"', () => {
+    const sheet = new Sheet(".btn\\\\:hover { color: red }")
+    rewriteStyleSheet(sheet)
+    expect(sheet.cssRules[0]).toEqual(".btn\\\\:hover, .btn\\\\.pseudo-hover, .pseudo-hover .btn\\\\ { color: red }")
+  })
 })


### PR DESCRIPTION
# Support pseudo selectors escape
This pull request adds support for escaping pseudo selectors, for example:
- `.btn\:hover` is a a class with no psuedo selector applied `<div class="btn:hover">`
- `.btn\\:hover` is a class with a psuedo selector applied `<div class="btn\">`

## Motivation:
In `tailwindcss` it's common to use classes containing `:` such as: `<div class="group-hover:peer-checked:hover:opacity-100">`.
At the moment these escaped classes lead to errors such as:
```
DOMException: Failed to execute 'insertRule' on 'CSSStyleSheet': Failed to parse the rule '.peer:placeholder-shown:focus ~ .peer-placeholder-shown\:peer-focus\:left-3, .peer:placeholder-shown.pseudo-focus ~ .peer-placeholder-shown\:peer-focus\:left-3, .pseudo-focus .peer:placeholder-show ~ .peer-placeholder-shown\:peer-focus\:left-3 { left: 0.75rem; }'.
    at rewriteStyleSheet (http://localhost:6006/node_modules/.vite-storybook/deps/storybook-addon-pseudo-states_dist_esm_preset_preview__js.js?v=fd8fff85:127:15)
    at http://localhost:6006/node_modules/.vite-storybook/deps/storybook-addon-pseudo-states_dist_esm_preset_preview__js.js?v=fd8fff85:217:46
    at Array.forEach (<anonymous>)
    at rewriteStyleSheets (http://localhost:6006/node_modules/.vite-storybook/deps/storybook-addon-pseudo-states_dist_esm_preset_preview__js.js?v=fd8fff85:217:27)
    at Object.<anonymous> (http://localhost:6006/node_modules/.vite-storybook/deps/storybook-addon-pseudo-states_dist_esm_preset_preview__js.js?v=fd8fff85:220:34)
    at http://localhost:6006/node_modules/.vite-storybook/deps/chunk-2XEYCXA4.js?v=fd8fff85:233:18
    at Array.forEach (<anonymous>)
    at Channel2.handleEvent (http://localhost:6006/node_modules/.vite-storybook/deps/chunk-2XEYCXA4.js?v=fd8fff85:232:23)
    at handler2 (http://localhost:6006/node_modules/.vite-storybook/deps/chunk-2XEYCXA4.js?v=fd8fff85:162:20)
    at Channel2.emit (http://localhost:6006/node_modules/.vite-storybook/deps/chunk-2XEYCXA4.js?v=fd8fff85:167:13) null
```
As well as unwanted behaviour, the class mentioned above with corresponding styles:
```css
.group:hover .peer:checked ~ .group-hover\:peer-checked\:hover\:opacity-100:hover {
  opacity: 1;
}
```
is being rewritten incorrectly causing, conditional styles to not be applied.
Here is a comparison of resulting classes before and after pull request:
```diff
- .group.pseudo-hover .peer:checked ~ .group-hover\:peer-checked\.pseudo-hover\:opacity-100.pseudo-hover
+ .group.pseudo-hover .peer:checked ~ .group-hover\:peer-checked\:hover\:opacity-100.pseudo-hover
```

