### PR TITLE
Remove optional chaining

### DIFF
--- a/src/PseudoStateTool.js
+++ b/src/PseudoStateTool.js
@@ -18,7 +18,10 @@ const options = Object.keys(PSEUDO_STATES).sort()
 
 export const PseudoStateTool = () => {
   const [{ pseudo }, updateGlobals] = useGlobals()
-  const isActive = useCallback((option) => pseudo?.[option] === true, [pseudo])
+  const isActive = useCallback((option) => {
+      if (!pseudo) return false
+      return pseudo[option] === true;
+  }, [pseudo])
 
   const toggleOption = useCallback(
     (option) => () => updateGlobals({ pseudo: { ...pseudo, [option]: !isActive(option) } }),

--- a/src/withPseudoState.js
+++ b/src/withPseudoState.js
@@ -93,7 +93,7 @@ export const withPseudoState = (StoryFn, { viewMode, parameters, id, globals: gl
 // Rewrite CSS rules for pseudo-states on all stylesheets to add an alternative selector
 const rewriteStyleSheets = (shadowRoot) => {
   let styleSheets = shadowRoot ? shadowRoot.styleSheets : document.styleSheets
-  if (shadowRoot?.adoptedStyleSheets?.length) styleSheets = shadowRoot.adoptedStyleSheets
+  if (shadowRoot && shadowRoot.adoptedStyleSheets ? shadowRoot.adoptedStyleSheets.length : undefined) styleSheets = shadowRoot.adoptedStyleSheets
   Array.from(styleSheets).forEach((sheet) => rewriteStyleSheet(sheet, shadowRoot, shadowHosts))
 }
 


### PR DESCRIPTION
Closes #48 

You can test by changing

`.storybook/main.js`
```diff
-  core: {
-    builder: "webpack5",
-  },
```
`package.json`
```diff
-    "build:storybook": "build-storybook",
+    "build:storybook": "NODE_OPTIONS=--openssl-legacy-provider build-storybook",
```

I'm definitely for changing it back to optional chaining in 2.0