### PR TITLE
Fix media queries breaking rules override

### DIFF
--- a/src/preview/rewriteStyleSheet.ts
+++ b/src/preview/rewriteStyleSheet.ts
@@ -67,8 +67,9 @@ export const rewriteStyleSheet = (
   sheet.__pseudoStatesRewritten = true
 
   try {
-    let index = 0
+    let index = -1
     for (const cssRule of sheet.cssRules) {
+      index++
       if (!("selectorText" in cssRule)) continue
       const styleRule = cssRule as CSSStyleRule
       if (matchOne.test(styleRule.selectorText)) {
@@ -77,7 +78,6 @@ export const rewriteStyleSheet = (
         sheet.insertRule(newRule, index)
         if (shadowRoot && shadowHosts) shadowHosts.add(shadowRoot.host)
       }
-      index++
       if (index > 1000) {
         warnOnce("Reached maximum of 1000 pseudo selectors per sheet, skipping the rest.")
         break


### PR DESCRIPTION
Closes #57 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.15.5--canary.58.b3ff6ae.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-pseudo-states@1.15.5--canary.58.b3ff6ae.0
  # or 
  yarn add storybook-addon-pseudo-states@1.15.5--canary.58.b3ff6ae.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
