### PR TITLE
Remove optional chaining in next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# v1.15.5 (Thu Mar 23 2023)
+
+#### 🐛 Bug Fix
+
+- Remove optional chaining [#52](https://github.com/chromaui/storybook-addon-pseudo-states/pull/52) ([@filipw01](https://github.com/filipw01))
+
+#### ⚠️ Pushed to `main`
+
+- 1.15.4 ([@ghengeveld](https://github.com/ghengeveld))
+
+#### Authors: 2
+
+- Filip Wachowiak ([@filipw01](https://github.com/filipw01))
+- Gert Hengeveld ([@ghengeveld](https://github.com/ghengeveld))
+
+---
+
 # v1.15.2 (Tue Dec 13 2022)
 
 #### 🐛 Bug Fix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storybook-addon-pseudo-states",
-  "version": "1.15.2",
+  "version": "1.15.5",
   "description": "CSS pseudo states for Storybook",
   "keywords": [
     "storybook-addons",

--- a/src/manager/PseudoStateTool.tsx
+++ b/src/manager/PseudoStateTool.tsx
@@ -18,7 +18,10 @@ const options = Object.keys(PSEUDO_STATES).sort()
 
 export const PseudoStateTool = () => {
   const [{ pseudo }, updateGlobals] = useGlobals()
-  const isActive = useCallback((option) => pseudo?.[option] === true, [pseudo])
+  const isActive = useCallback((option) => {
+      if (!pseudo) return false
+      return pseudo[option] === true;
+  }, [pseudo])
 
   const toggleOption = useCallback(
     (option) => () => updateGlobals({ pseudo: { ...pseudo, [option]: !isActive(option) } }),


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.15.6--canary.70.86b7d66.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-pseudo-states@1.15.6--canary.70.86b7d66.0
  # or 
  yarn add storybook-addon-pseudo-states@1.15.6--canary.70.86b7d66.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
