### PR TITLE
Add pseudoDelay parameter

### DIFF
--- a/src/preview/withPseudoState.ts
+++ b/src/preview/withPseudoState.ts
@@ -124,7 +124,7 @@ export const withPseudoState: DecoratorFunction = (
     const timeout = setTimeout(() => {
       applyParameter(rootElement, globals || pseudoConfig(parameter))
       shadowHosts.forEach(updateShadowHost)
-    }, 0)
+    }, parameters.pseudoDelay || 0)
     return () => clearTimeout(timeout)
   }, [rootElement, globals, parameter])
 


### PR DESCRIPTION
**DO NOT MERGE**: This is for debugging a race condition in a customer setup. The theory is that the pseudostates are getting overridden by a custom decorator. By setting `parameters.pseudoDelay` to 100 or some other value, perhaps we can force it to apply last. If that works, we'll have more information to help fix their setup or possibly have a workaround if this is merged.