### PR TITLE
Exclude ::-webkit-slider-thumb pseudo-element from rewrites

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,7 +4,7 @@ export const PARAM_KEY = "pseudo"
 
 // Pseudo-elements which are not allowed to have classes applied on them
 // E.g. ::-webkit-scrollbar-thumb.pseudo-hover is not a valid selector
-export const EXCLUDED_PSEUDO_ELEMENTS = ["::-webkit-scrollbar-thumb"]
+export const EXCLUDED_PSEUDO_ELEMENTS = ["::-webkit-scrollbar-thumb", "::-webkit-slider-thumb"]
 
 // Dynamic pseudo-classes
 // @see https://www.w3.org/TR/2018/REC-selectors-3-20181106/#dynamic-pseudos


### PR DESCRIPTION
Fixes #37 (and #98 and #26, which are duplicates)