### PR TITLE
Add `author` and `publishConfig` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/chromaui/storybook-addon-pseudo-states"
+    "url": "git+https://github.com/chromaui/storybook-addon-pseudo-states.git"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "type": "git",
     "url": "https://github.com/chromaui/storybook-addon-pseudo-states"
   },
-  "author": "ghengeveld",
+  "publishConfig": {
+    "access": "public"
+  },
+  "author": "Chromatic <support@chromatic.com>",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
This should fix the [git author issue](https://github.com/chromaui/storybook-addon-pseudo-states/actions/runs/8420645901/job/23055776408#step:6:231) in the release action.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.2.2--canary.109.b2d7be1.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-pseudo-states@2.2.2--canary.109.b2d7be1.0
  # or 
  yarn add storybook-addon-pseudo-states@2.2.2--canary.109.b2d7be1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
