### PR TITLE
Avoid invalid `::part` selector

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,9 +2,9 @@ export const ADDON_ID = "storybook/pseudo-states"
 export const TOOL_ID = `${ADDON_ID}/tool`
 export const PARAM_KEY = "pseudo"
 
-// Pseudo-elements which are not allowed to have classes applied on them
+// Regex patterns for pseudo-elements which are not allowed to have classes applied on them
 // E.g. ::-webkit-scrollbar-thumb.pseudo-hover is not a valid selector
-export const EXCLUDED_PSEUDO_ELEMENTS = ["::-webkit-scrollbar-thumb", "::-webkit-slider-thumb"]
+export const EXCLUDED_PSEUDO_ELEMENT_PATTERNS = ["::-webkit-scrollbar-thumb", "::-webkit-slider-thumb", "::part\\([^)]+\\)"]
 
 // Dynamic pseudo-classes
 // @see https://www.w3.org/TR/2018/REC-selectors-3-20181106/#dynamic-pseudos

--- a/src/preview/rewriteStyleSheet.test.ts
+++ b/src/preview/rewriteStyleSheet.test.ts
@@ -137,10 +137,28 @@ describe("rewriteStyleSheet", () => {
     ].includes(x))).toEqual([])
   })
 
-  it("does not add .pseudo-<class> to pseudo-class, which does not support classes", () => {
+  it("does not add .pseudo-<class> to pseudo-class/element which does not support classes", () => {
     const sheet = new Sheet("::-webkit-scrollbar-thumb:hover { border-color: transparent; }")
     rewriteStyleSheet(sheet as any)
     expect(sheet.cssRules[0].getSelectors()).not.toContain("::-webkit-scrollbar-thumb.pseudo-hover")
+  })
+
+  it("adds alternative selector when ::-webkit-scrollbar-thumb follows :hover", () => {
+    const sheet = new Sheet("div:hover::-webkit-scrollbar-thumb { border-color: transparent; }")
+    rewriteStyleSheet(sheet as any)
+    expect(sheet.cssRules[0].getSelectors()).toContain("div.pseudo-hover::-webkit-scrollbar-thumb")
+  })
+
+  it("does not add .pseudo-<class> to pseudo-class/element (with arguments) which does not support classes", () => {
+    const sheet = new Sheet("::part(foo bar):hover { border-color: transparent; }")
+    rewriteStyleSheet(sheet as any)
+    expect(sheet.cssRules[0].getSelectors()).not.toContain("::part(foo bar).pseudo-hover")
+  })
+
+  it("adds alternative selector when ::part() follows :hover", () => {
+    const sheet = new Sheet("custom-elt:hover::part(foo bar) { border-color: transparent; }")
+    rewriteStyleSheet(sheet as any)
+    expect(sheet.cssRules[0].getSelectors()).toContain("custom-elt.pseudo-hover::part(foo bar)")
   })
 
   it("adds alternative selector for each pseudo selector", () => {

--- a/src/preview/withPseudoState.ts
+++ b/src/preview/withPseudoState.ts
@@ -82,10 +82,10 @@ const applyParameter = (rootElement: Element, parameter: PseudoStateConfig = {})
 // Shadow DOM can only access classes on its host. Traversing is needed to mimic the CSS cascade.
 const updateShadowHost = (shadowHost: Element) => {
   const classnames = new Set<string>()
-  // Keep any existing "pseudo-*" classes
+  // Keep any existing "pseudo-*" classes (but not "pseudo-*-all")
   shadowHost.className
     .split(" ")
-    .filter((classname) => classname.startsWith("pseudo-"))
+    .filter((classname) => classname.match(/^pseudo-(.(?!-all))+$/))
     .forEach((classname) => classnames.add(classname))
   // Adopt "pseudo-*-all" classes from ancestors (across shadow boundaries)
   for (let node = shadowHost.parentNode; node;) {
@@ -174,10 +174,8 @@ export const withPseudoState: DecoratorFunction = (
 const rewriteStyleSheets = (shadowRoot?: ShadowRoot) => {
   let styleSheets = Array.from(shadowRoot ? shadowRoot.styleSheets : document.styleSheets)
   if (shadowRoot?.adoptedStyleSheets?.length) styleSheets = shadowRoot.adoptedStyleSheets
-  const rewroteStyles = styleSheets
-    .map((sheet) => rewriteStyleSheet(sheet, shadowRoot))
-    .some(Boolean)
-  if (rewroteStyles && shadowRoot && shadowHosts) shadowHosts.add(shadowRoot.host)
+  styleSheets.forEach((sheet) => rewriteStyleSheet(sheet, shadowRoot))
+  if (shadowRoot && shadowHosts) shadowHosts.add(shadowRoot.host)
 }
 
 // Only track shadow hosts for the current story

--- a/src/preview/withPseudoState.ts
+++ b/src/preview/withPseudoState.ts
@@ -82,7 +82,8 @@ const applyParameter = (rootElement: Element, parameter: PseudoStateConfig = {})
 // Shadow DOM can only access classes on its host. Traversing is needed to mimic the CSS cascade.
 const updateShadowHost = (shadowHost: Element) => {
   const classnames = new Set<string>()
-  // Keep any existing "pseudo-*" classes (but not "pseudo-*-all")
+  // Keep any existing "pseudo-*" classes (but not "pseudo-*-all").
+  // "pseudo-*-all" classes may be stale and will be re-added as needed.
   shadowHost.className
     .split(" ")
     .filter((classname) => classname.match(/^pseudo-(.(?!-all))+$/))

--- a/stories/ShadowRootWithPart.js
+++ b/stories/ShadowRootWithPart.js
@@ -1,0 +1,42 @@
+import React from "react"
+
+export const ShadowRoot = ({ label = "Hello from shadow DOM" }) => {
+  const ref = React.useRef()
+
+  React.useEffect(() => {
+    if (!ref.current.attachShadow) return
+    ref.current.attachShadow({ mode: "closed" })
+    ref.current.shadowRoot.innerHTML = `
+      <button part="foo">${label}</button>
+    `
+    ref.current.innerHTML = `
+      <style>
+        ::part(foo) {
+          font-family: "Nunito Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+          font-weight: 700;
+          border: 0;
+          border-radius: 3em;
+          cursor: pointer;
+          display: inline-block;
+          line-height: 1;
+          color: white;
+          background-color: tomato;
+          font-size: 14px;
+          padding: 11px 20px;
+        }
+        ::part(foo):hover {
+          text-decoration: underline;
+        }
+        ::part(foo):focus {
+          box-shadow: inset 0 0 0 2px maroon;
+          outline: 0;
+        }
+        ::part(foo):active {
+          background-color: firebrick;
+        }
+      </style>
+    `
+  }, [])
+
+  return <div ref={ref} />
+}

--- a/stories/ShadowRootWithPart.stories.js
+++ b/stories/ShadowRootWithPart.stories.js
@@ -1,0 +1,51 @@
+import React from "react"
+
+import { ShadowRoot } from "./ShadowRootWithPart"
+import "./grid.css"
+
+export default {
+  title: "Example/ShadowRootWithPart",
+  component: ShadowRoot,
+}
+
+const Template = () => <ShadowRoot />
+
+export const All = () => (
+  <div className="story-grid">
+    <div>
+      <ShadowRoot label="Normal" />
+    </div>
+    <div className="pseudo-hover-all">
+      <ShadowRoot label="Hover" />
+    </div>
+    <div className="pseudo-focus-all">
+      <ShadowRoot label="Focus" />
+    </div>
+    <div className="pseudo-active-all">
+      <ShadowRoot label="Active" />
+    </div>
+    <div className="pseudo-hover-all pseudo-focus-all">
+      <ShadowRoot label="Hover Focus" />
+    </div>
+    <div className="pseudo-hover-all pseudo-active-all">
+      <ShadowRoot label="Hover Active" />
+    </div>
+    <div className="pseudo-focus-all pseudo-active-all">
+      <ShadowRoot label="Focus Active" />
+    </div>
+    <div className="pseudo-hover-all pseudo-focus-all pseudo-active-all">
+      <ShadowRoot label="Hover Focus Active" />
+    </div>
+  </div>
+)
+
+export const Default = Template.bind()
+
+export const Hover = Template.bind()
+Hover.parameters = { pseudo: { hover: true } }
+
+export const Focus = Template.bind()
+Focus.parameters = { pseudo: { focus: true } }
+
+export const Active = Template.bind()
+Active.parameters = { pseudo: { active: true } }


### PR DESCRIPTION
It is not valid CSS to add a class selector to the `::part()` pseudo-element, so rewriting a selector like `::part(foo):hover` to `::part(foo).pseudo-hover` is a problem.

`::-webkit-scrollbar-thumb` and  `::-webkit-slider-thumb` have the same limitation, and there was already logic to avoid generating modified selectors that included those. However, that logic was overly restrictive, preventing valid rewrites like `div:hover::-webkit-scrollbar-thumb` -> `div.pseudo-hover::webkit-scrollbar-thumb`.

This change includes:
- prevents generating invalid CSS with `::part()` followed by a class selector
- support for selectors like `elt:hover::part(foo)` and `elt:hover::-webkit-scrollbar-thumb`
- make sure `pseudo-*-all` classes get added to shadow hosts, even if their shadow DOM didn't have stylesheets that got rewritten. This is necessary to support `::part()`-based styling, since those styles are (usually) in the light DOM.
- make sure stale `pseudo-*-all` classes get cleared from shadow hosts when switching Storybook stories
- new Storybook story for `::part()` support