### PR TITLE
Add proper support for :not()

### DIFF
--- a/src/preview/withPseudoState.ts
+++ b/src/preview/withPseudoState.ts
@@ -175,7 +175,7 @@ export const withPseudoState: DecoratorFunction = (
 const rewriteStyleSheets = (shadowRoot?: ShadowRoot) => {
   let styleSheets = Array.from(shadowRoot ? shadowRoot.styleSheets : document.styleSheets)
   if (shadowRoot?.adoptedStyleSheets?.length) styleSheets = shadowRoot.adoptedStyleSheets
-  styleSheets.forEach((sheet) => rewriteStyleSheet(sheet, shadowRoot))
+  styleSheets.forEach((sheet) => rewriteStyleSheet(sheet, !!shadowRoot))
   if (shadowRoot && shadowHosts) shadowHosts.add(shadowRoot.host)
 }
 


### PR DESCRIPTION
The code avoided generating invalid CSS when a rule included `:not()`, but it did not provide correct support for the `pseudo-*-all` classes. For example, `:not(:hover)` would be transformed to `.pseudo-hover-all :not()`, but we would skip writing that rule, because of the invalid (i.e. empty) `:not()`. The correct rewriting of that rule is `:not(.pseudo-hover-all *)`, i.e. "Not a descendant of an element with class `.pseudo-hover-all`". Similarly, for shadow DOM styles, we need special logic to turn the example rule into `:not(:host(.pseudo-hover-all) *)`.

In general, the approach is:
1. Replace `:not(...<pseudo-state>...)` with `:not(.pseudo-<state>-all ...)` (or `:not(:host(.pseudo-<state>-all) ...)` if for shadow DOM)
2. Extract remaining pseudo-states and move them to an ancestor selector: `...<pseudo-state>...` -> `.pseudo-<state>-all ...`

Additionally, the refactoring I did allowed the removal of special logic related to `::slotted()` and `:has()`.