### PR TITLE
Fix regression in pseudo-element handling

### DIFF
--- a/src/preview/rewriteStyleSheet.test.ts
+++ b/src/preview/rewriteStyleSheet.test.ts
@@ -141,6 +141,7 @@ describe("rewriteStyleSheet", () => {
     const sheet = new Sheet("::-webkit-scrollbar-thumb:hover { border-color: transparent; }")
     rewriteStyleSheet(sheet as any)
     expect(sheet.cssRules[0].getSelectors()).not.toContain("::-webkit-scrollbar-thumb.pseudo-hover")
+    expect(sheet.cssRules[0].getSelectors()).toContain(".pseudo-hover-all ::-webkit-scrollbar-thumb")
   })
 
   it("adds alternative selector when ::-webkit-scrollbar-thumb follows :hover", () => {
@@ -153,6 +154,7 @@ describe("rewriteStyleSheet", () => {
     const sheet = new Sheet("::part(foo bar):hover { border-color: transparent; }")
     rewriteStyleSheet(sheet as any)
     expect(sheet.cssRules[0].getSelectors()).not.toContain("::part(foo bar).pseudo-hover")
+    expect(sheet.cssRules[0].getSelectors()).toContain(".pseudo-hover-all ::part(foo bar)")
   })
 
   it("adds alternative selector when ::part() follows :hover", () => {

--- a/stories/ShadowRootWithPart.css
+++ b/stories/ShadowRootWithPart.css
@@ -1,0 +1,23 @@
+::part(foo) {
+  font-family: "Nunito Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 700;
+  border: 0;
+  border-radius: 3em;
+  cursor: pointer;
+  display: inline-block;
+  line-height: 1;
+  color: white;
+  background-color: tomato;
+  font-size: 14px;
+  padding: 11px 20px;
+}
+::part(foo):hover {
+  text-decoration: underline;
+}
+::part(foo):focus {
+  box-shadow: inset 0 0 0 2px maroon;
+  outline: 0;
+}
+::part(foo):active {
+  background-color: firebrick;
+}

--- a/stories/ShadowRootWithPart.js
+++ b/stories/ShadowRootWithPart.js
@@ -1,4 +1,5 @@
 import React from "react"
+import "./ShadowRootWithPart.css"
 
 export const ShadowRoot = ({ label = "Hello from shadow DOM" }) => {
   const ref = React.useRef()
@@ -8,33 +9,6 @@ export const ShadowRoot = ({ label = "Hello from shadow DOM" }) => {
     ref.current.attachShadow({ mode: "closed" })
     ref.current.shadowRoot.innerHTML = `
       <button part="foo">${label}</button>
-    `
-    ref.current.innerHTML = `
-      <style>
-        ::part(foo) {
-          font-family: "Nunito Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
-          font-weight: 700;
-          border: 0;
-          border-radius: 3em;
-          cursor: pointer;
-          display: inline-block;
-          line-height: 1;
-          color: white;
-          background-color: tomato;
-          font-size: 14px;
-          padding: 11px 20px;
-        }
-        ::part(foo):hover {
-          text-decoration: underline;
-        }
-        ::part(foo):focus {
-          box-shadow: inset 0 0 0 2px maroon;
-          outline: 0;
-        }
-        ::part(foo):active {
-          background-color: firebrick;
-        }
-      </style>
     `
   }, [])
 


### PR DESCRIPTION
When improving support for `:not()`, I had made a change that accidentally prevented rewriting rules that had pseudo-elements with pseudo-states applied, e.g. `::part(foo):active` or `::-webkit-scrollbar-thumb:hover`. Though we want to avoid generating selectors that apply classes to these pseudo-elements (it is invalid CSS), we still want to generate the selectors involving the `.pseudo-<state>-all` classes. Since we do not append those classes to the pseudo-elements (e.g. `.pseudo-active-all ::part(foo)`), they are valid CSS.

I have updated the tests to ensure we generate the `.pseudo-<state>-all`-based selectors, but not the `.pseudo-<state>`-based ones.

Even after this fix, I noticed that the ShadowRootWithPart story was not consistently being rendered properly. It turned out that the stylesheet rewrite was happening before the `React.useEffect` hook was inserting the styles into the element. By switching to including the styles by importing, the timing issue is resolved.