### PR TITLE
Fix CJS entrypoint for manager code, and drop some unused things

### DIFF
--- a/manager.js
+++ b/manager.js
@@ -1,1 +1,0 @@
-import "./dist/manager.mjs"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
       "require": "./dist/index.js"
     },
     "./manager": {
-      "types": "./dist/manager.d.ts",
       "import": "./dist/manager.mjs",
       "require": "./dist/manager.js"
     },
@@ -39,7 +38,6 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "*.js",
     "dist/**/*"
   ],
   "scripts": {

--- a/preview.js
+++ b/preview.js
@@ -1,1 +1,0 @@
-export * from "./dist/preview.mjs"

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -71,7 +71,7 @@ export default defineConfig(async (options) => {
     configs.push({
       ...commonConfig,
       entry: managerEntries,
-      format: ["esm"],
+      format: ["esm", "cjs"],
       target: BROWSER_TARGET,
       platform: "browser",
       external: globalManagerPackages,


### PR DESCRIPTION
The addon was broken because package.json is pointing to `./dist/manager.js` for the manager `require` entrypoint, but this file did not exist. I've updated the TSUP config to generate this file. I've dropped the files at the root because nothing is actually using these.