### PR TITLE
Update release workflow config to use `GH_TOKEN` 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.AUTO_RELEASE_TOKEN_GHENGEVELD }}
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Prepare repository
         run: git fetch --unshallow --tags
@@ -23,7 +23,7 @@ jobs:
 
       - name: Create Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Create Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           pnpm install


### PR DESCRIPTION
Auto expects `GH_TOKEN` as an environment variable.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.0.3--canary.128.fb67818.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-pseudo-states@4.0.3--canary.128.fb67818.0
  # or 
  yarn add storybook-addon-pseudo-states@4.0.3--canary.128.fb67818.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
