### PR TITLE
Do not replace :is() with :is(*)

### DIFF
--- a/src/preview/rewriteStyleSheet.test.ts
+++ b/src/preview/rewriteStyleSheet.test.ts
@@ -177,6 +177,12 @@ describe("rewriteStyleSheet", () => {
     expect(sheet.cssRules[0].getSelectors()).toContain("custom-elt.pseudo-hover::part(foo bar)")
   })
 
+  it("does not replace :is() with :is(*)", () => {
+    const sheet = new Sheet(":is():hover { color: red }")
+    rewriteStyleSheet(sheet as any)
+    expect(sheet.cssRules[0].getSelectors()).toContain(".pseudo-hover-all :is()")
+  })
+
   it("adds alternative selector for each pseudo selector", () => {
     const sheet = new Sheet("a:hover, a:focus { color: red }")
     rewriteStyleSheet(sheet as any)

--- a/src/preview/rewriteStyleSheet.ts
+++ b/src/preview/rewriteStyleSheet.ts
@@ -50,7 +50,8 @@ const extractPseudoStates = (selector: string) => {
       return ""
     })
     // If removing pseudo-state selectors from inside a functional selector left it empty (thus invalid), must fix it by adding '*'.
-    .replaceAll("()", "(*)")
+    // The negative lookbehind ensures we don't replace :is() with :is(*).
+    .replaceAll(/(?<!is)\(\)/g, "(*)")
     // If a selector list was left with blank items (e.g. ", foo, , bar, "), remove the extra commas/spaces.
     .replace(/(?<=[\s(]),\s+|(,\s+)+(?=\))/g, "") || "*"
 


### PR DESCRIPTION
I noticed an odd behavior when processing this selector:

```css
:is():hover { color: red; }
```

The library was replacing this with:

```
.pseudo-hover-all :is(*) { color: red; }
```

Which ends up resulting in these styles applied everywhere! (everything has color red).

The changes on this PR handle that edge case.