### PR TITLE
Ignore escaped pseudo-class names in class selectors (e.g. .foo\:hover)

### DIFF
--- a/src/preview/rewriteStyleSheet.test.ts
+++ b/src/preview/rewriteStyleSheet.test.ts
@@ -171,6 +171,16 @@ describe("rewriteStyleSheet", () => {
     expect(sheet.cssRules[0].getSelectors()).toContain(".pseudo-hover-all ::part(foo bar)")
   })
 
+  it("does not replace escaped pseudo-class names (e.g. Tailwind variants)", () => {
+    const sheet = new Sheet(".foo\\:hover { cursor: default; }")
+    rewriteStyleSheet(sheet as any)
+    // expect(sheet.cssRules[0].getSelectors()).not.toContain(".foo\\:bar.pseudo-hover")
+    console.log(sheet.cssRules[0].getSelectors())
+    expect(sheet.cssRules[0].getSelectors().filter((x) => ![".foo\\:hover"].includes(x))).toEqual(
+      [],
+    )
+  })
+
   it("adds alternative selector when .pseudo-<class> would not be appended to ::part()", () => {
     const sheet = new Sheet("custom-elt:hover::part(foo bar) { border-color: transparent; }")
     rewriteStyleSheet(sheet as any)

--- a/src/preview/rewriteStyleSheet.ts
+++ b/src/preview/rewriteStyleSheet.ts
@@ -2,7 +2,8 @@ import { PSEUDO_STATES, EXCLUDED_PSEUDO_ELEMENT_PATTERNS } from "../constants"
 import { splitSelectors } from "./splitSelectors"
 
 const pseudoStates = Object.values(PSEUDO_STATES)
-const pseudoStatesPattern = `:(${pseudoStates.join("|")})`
+// The negative lookbehind ensures we don't match escaped pseudo-states commonly used in Tailwind (e.g. .foo\:hover:hover).
+const pseudoStatesPattern = `(?<!\\\\):(${pseudoStates.join("|")})`
 const matchOne = new RegExp(pseudoStatesPattern)
 const matchAll = new RegExp(pseudoStatesPattern, "g")
   


### PR DESCRIPTION
These are used heavily in Tailwind-generated styles. See https://tailwindcss.com/docs/hover-focus-and-other-states

Fixes storybookjs/storybook#31409